### PR TITLE
Fix README and setlist validation, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ setlist-generator/
    - Windows: `venv\Scripts\activate`
    - macOS/Linux: `source venv/bin/activate`
 4. Install dependencies: `pip install -r requirements.txt`
-5. Run the Flask application: `python app.py`
+5. Run the Flask application: `python run.py`
 
 ### Frontend Setup
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,7 +18,7 @@ class Song(db.Model):
     # Song parameters
     tempo = db.Column(db.Integer)  # Actual BPM
     tempo_category = db.Column(db.String(20))  # slow, medium, fast
-    intensity = db.Column(db.String(20))  # slow, medium, fast
+    intensity = db.Column(db.String(20))  # low, medium, high
     lead_vocalist = db.Column(db.String(50))
     key = db.Column(db.String(20))  # e.g., A Minor, B Major
     is_minor = db.Column(db.Boolean, default=False)  # True if minor, False if major

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ Flask-SQLAlchemy==3.0.3
 pandas==1.5.3
 numpy==1.24.2
 python-dotenv==1.0.0
+pytest==7.4.0

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -184,6 +184,8 @@ def generate_setlist():
     
     # Calculate remaining duration after including hit songs
     hit_songs_duration = sum(song.duration or 0 for song in hit_songs)
+    if hit_songs_duration > target_duration:
+        return jsonify({'error': 'Hit songs exceed target duration'}), 400
     remaining_duration = target_duration - hit_songs_duration
     
     # Filter out hit songs from the pool of available songs

--- a/tests/test_generate_setlist.py
+++ b/tests/test_generate_setlist.py
@@ -1,0 +1,28 @@
+import pytest
+
+from backend.app import create_app
+from backend.models import db, Song
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+
+def test_generate_setlist_hits_exceed_duration(client):
+    # Add two hit songs whose total duration exceeds the request
+    with client.application.app_context():
+        db.session.add_all([
+            Song(title='Hit 1', artist='A', duration=400, is_hit=True),
+            Song(title='Hit 2', artist='B', duration=400, is_hit=True)
+        ])
+        db.session.commit()
+
+    resp = client.post('/api/generate-setlist', json={'target_duration': 500})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert 'Hit songs exceed' in data.get('error', '')


### PR DESCRIPTION
## Summary
- update intensity comment to `low, medium, high`
- reject setlist generation when hit songs exceed requested duration
- document using `python run.py` in the README
- add pytest and a unit test for `/generate-setlist`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*