### PR TITLE
Remove BPM text in tempo column

### DIFF
--- a/frontend/src/app/components/setlist-view/setlist-view.component.html
+++ b/frontend/src/app/components/setlist-view/setlist-view.component.html
@@ -81,8 +81,7 @@
               <span [class]="getKeyTypeClass(song.is_minor)" class="ms-1">{{ getKeyTypeLabel(song.is_minor) }}</span>
             </td>
             <td>
-              {{ song.tempo }} BPM
-              <span *ngIf="song.tempo_category" [class]="getTempoClass(song.tempo_category)" class="ms-1">{{ song.tempo_category }}</span>
+              <span *ngIf="song.tempo_category" [class]="getTempoClass(song.tempo_category)">{{ song.tempo_category }}</span>
             </td>
             <td>{{ song.lead_vocalist || 'N/A' }}</td>
             <td>


### PR DESCRIPTION
## Summary
- update setlist view so tempo column only shows Slow/Medium/Fast label

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'flask')*